### PR TITLE
Adjust GetStarted.md to fix clarity/mistakes

### DIFF
--- a/GetStarted.md
+++ b/GetStarted.md
@@ -5,9 +5,39 @@ and also uses [this](https://guides.rubyonrails.org/install_ruby_on_rails.html).
 
 ## Initial setup
 
-First install ```ruby```, ```rails```, ```docker```, ```docker-buildx```, ```docker-compose```, and ```mysql```.
+First, clone the Casino repo. Then install the dependencies below.
 
-Then, clone the Casino repo.
+### WSL
+
+For WSL, install Docker Desktop on Windows, and run it. Ensure docker is available in WSL by running
+
+```sh
+docker --version
+```
+
+Then run
+
+```sh
+sudo apt install ruby libmysqlclient-dev
+```
+
+in a WSL terminal.
+
+### Mac
+
+On Mac, docker must be installed as a cask using:
+
+```sh
+brew install --cask docker
+```
+
+If docker is installed, but not as a cask, remove it first, then install with the above command.
+
+Then install Ruby and MySQL with brew or a downloadable installer.
+
+### Linux
+
+On Linux (not WSL), install ```docker```, ```docker-buildx```, ```docker-compose```, ```ruby```, and ```mysql``` (or whatever packages provide them) with your system's package manager, and enable/start the Docker daemon.
 
 ### Environment
 
@@ -33,41 +63,16 @@ Also don't commit these passwords anywhere, they are meant to be secure.
 
 ## Running Docker
 
-The Docker daemon will need to be running to use Docker. Depending on your operating system, this will be different.
-
-### MacOS
-
-Install docker as a cask using
+The Docker daemon will need to be running to use Docker. Ensure Docker is running, and confirm in the command line using:
 
 ```sh
-brew install --cask docker
+docker --version
 ```
 
-If docker is installed, but not as a cask, remove it first, then install with the above command.
-
-To run it, launch the docker GUI application, follow the setup steps, and make sure the docker icon is showing in the status bar.
-
-### Linux and WSL
-
-WSL users will need to enable systemd by adding
-
-```txt
-[boot]
-systemd=true
-```
-
-to ```/etc/wsl.conf```, and rebooting.
-
-The Docker daemon can be enabled with Systemd using
+In WSL and Linux, docker needs to be run with ```sudo``` by default. If you don't want to use ```sudo``` every time, add your username to the ```docker``` group with:
 
 ```sh
-systemctl enable --now docker
-```
-
-or as a socket (to be run when needed, instead of at boot) with
-
-```sh
-systemctl enable --now docker.socket
+sudo gpasswd -a <username> docker
 ```
 
 ## Database
@@ -75,13 +80,13 @@ systemctl enable --now docker.socket
 To run the database on its own, use
 
 ```sh
-docker compose up db
+docker-compose up db
 ```
 
 It can be run in the background using the ```-d``` flag. To stop it, use
 
 ```sh
-docker compose stop db
+docker-compose stop db
 ```
 
 ## Web app
@@ -91,6 +96,7 @@ docker compose stop db
 Before running rails in development mode for the first time, gems need to be installed and the database needs to be generated. With the database set up and running, run
 
 ```sh
+gem install rails
 bin/bundle install
 bin/rails db:create
 bin/rails db:migrate
@@ -104,7 +110,19 @@ Also, whenever new migrations are added, you will need to apply them to your dat
 bin/rails db:migrate
 ```
 
-### mysql2 on Apple silicone (M1, M2, etc. chips)
+### If you get gem install errors (WSL/Linux)
+
+If you get write permission errors, you might have to manually set the gem home with
+
+```sh
+export GEM_HOME=$HOME/.gem
+```
+
+This will need to be re-run every time a new terminal is opened.
+
+If gems fail to build, you might need to install ```ruby-dev```, ```libyaml-dev```, and ```make``` with your system's package manager, and then install ```mail```, ```xpath``` and any other missing gems manually with ```gem```.
+
+### If mysql2 fails to build on Apple silicone (M1, M2, etc. chips)
 
 The ```mysql2``` gem is complicated to install on Apple hardware, and might cause the bundle install to fail. If that happens, first install ```openssl``` with brew, then install ```mysql2``` with this command:
 
@@ -131,7 +149,7 @@ Note that the database must be running for this to work properly.
 To build the web app, run
 
 ```sh
-docker compose build
+docker-compose build
 ```
 
 ### Running in production
@@ -139,25 +157,25 @@ docker compose build
 The database and web app can be run together in production mode by running
 
 ```sh
-docker compose up
+docker-compose up
 ```
 
 or the web app can be run independently with
 
 ```sh
-docker compose up web
+docker-compose up web
 ```
 
 Either can be run in the background using the ```-d``` flag, and then stopped with
 
 ```sh
-docker compose stop
+docker-compose stop
 ```
 
 or
 
 ```sh
-docker compose stop web
+docker-compose stop web
 ```
 
 respectively.


### PR DESCRIPTION
For #54. Simple fix for GetStarted.md to fix some incorrect instructions for WSL/Linux, cover some extra issues that might happen, and fix some mistakes.