### PR TITLE
[#123] Use the actual image name in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       retries: 20
 
   web:
-    image: casino
+    image: comp4350thehouse/casino
     build: .
     environment:
       DB_HOST: db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       retries: 20
 
   web:
-    image: comp4350thehouse/casino
+    image: comp4350thehouse/casino:main
     build: .
     environment:
       DB_HOST: db


### PR DESCRIPTION
Just changes the pulled image in docker-compose from "casino" to "comp4350thehouse/casino" so it can pull from the Docker Hub repo.