### PR TITLE
136 use latest tag

### DIFF
--- a/.github/workflows/rubyonrails_cd.yml
+++ b/.github/workflows/rubyonrails_cd.yml
@@ -33,7 +33,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: COMP4350TheHouse/casino
+          images: COMP4350TheHouse/casino:latest
       
       - name: Build and push Docker image
         id: push

--- a/.github/workflows/rubyonrails_cd.yml
+++ b/.github/workflows/rubyonrails_cd.yml
@@ -34,7 +34,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: comp4350TheHouse/casino
-          tags: latest
+          # tags: latest
       
       - name: Build and push Docker image
         id: push
@@ -42,12 +42,13 @@ jobs:
         with:
           context: .
           push: true
-          tags: comp4350TheHouse/casino:latest
+          # tags: comp4350TheHouse/casino:latest
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: index.docker.io/comp4350TheHouse/casino
+          subject-name: index.docker.io/COMP4350TheHouse/casino
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/rubyonrails_cd.yml
+++ b/.github/workflows/rubyonrails_cd.yml
@@ -34,7 +34,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: comp4350TheHouse/casino
-          # tags: latest
+          tags: latest
       
       - name: Build and push Docker image
         id: push

--- a/.github/workflows/rubyonrails_cd.yml
+++ b/.github/workflows/rubyonrails_cd.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - 136-use-latest-tag
 
 jobs:
   push_to_registry:

--- a/.github/workflows/rubyonrails_cd.yml
+++ b/.github/workflows/rubyonrails_cd.yml
@@ -47,6 +47,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: index.docker.io/COMP4350TheHouse/casino:latest
+          subject-name: index.docker.io/COMP4350TheHouse/casino
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/rubyonrails_cd.yml
+++ b/.github/workflows/rubyonrails_cd.yml
@@ -33,7 +33,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: COMP4350TheHouse/casino:latest
+          images: COMP4350TheHouse/casino
       
       - name: Build and push Docker image
         id: push
@@ -41,7 +41,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: latest
           labels: ${{ steps.meta.outputs.labels }}
       
       - name: Generate artifact attestation

--- a/.github/workflows/rubyonrails_cd.yml
+++ b/.github/workflows/rubyonrails_cd.yml
@@ -34,6 +34,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: COMP4350TheHouse/casino
+          tags: |
+            type=raw,latest
       
       - name: Build and push Docker image
         id: push
@@ -41,7 +43,6 @@ jobs:
         with:
           context: .
           push: true
-          tags: latest
           labels: ${{ steps.meta.outputs.labels }}
       
       - name: Generate artifact attestation

--- a/.github/workflows/rubyonrails_cd.yml
+++ b/.github/workflows/rubyonrails_cd.yml
@@ -41,7 +41,6 @@ jobs:
         with:
           context: .
           push: true
-          # tags: comp4350TheHouse/casino:latest
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       

--- a/.github/workflows/rubyonrails_cd.yml
+++ b/.github/workflows/rubyonrails_cd.yml
@@ -32,7 +32,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: comp4350TheHouse/casino
+          images: comp4350thetouse/casino
           tags: latest
       
       - name: Build and push Docker image
@@ -47,6 +47,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: index.docker.io/COMP4350TheHouse/casino
+          subject-name: index.docker.io/comp4350thehouse/casino
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/rubyonrails_cd.yml
+++ b/.github/workflows/rubyonrails_cd.yml
@@ -34,8 +34,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: comp4350TheHouse/casino
-          tags: |
-            type=raw,latest
+          tags: latest
       
       - name: Build and push Docker image
         id: push
@@ -43,7 +42,7 @@ jobs:
         with:
           context: .
           push: true
-          # tags: comp4350TheHouse/casino
+          tags: comp4350TheHouse/casino:latest
           labels: ${{ steps.meta.outputs.labels }}
       
       - name: Generate artifact attestation

--- a/.github/workflows/rubyonrails_cd.yml
+++ b/.github/workflows/rubyonrails_cd.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - 136-user-latest-tag
+      - 136-use-latest-tag
 
 jobs:
   push_to_registry:

--- a/.github/workflows/rubyonrails_cd.yml
+++ b/.github/workflows/rubyonrails_cd.yml
@@ -33,7 +33,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: COMP4350TheHouse/casino
+          images: comp4350TheHouse/casino
           tags: |
             type=raw,latest
       
@@ -43,12 +43,12 @@ jobs:
         with:
           context: .
           push: true
-          tags: COMP4350TheHouse/casino:latest
+          tags: comp4350TheHouse/casino:latest
           labels: ${{ steps.meta.outputs.labels }}
       
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: index.docker.io/COMP4350TheHouse/casino:latest
+          subject-name: index.docker.io/comp4350TheHouse/casino
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/rubyonrails_cd.yml
+++ b/.github/workflows/rubyonrails_cd.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - 136-user-latest-tag
 
 jobs:
   push_to_registry:
@@ -46,6 +47,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: index.docker.io/COMP4350TheHouse/casino
+          subject-name: index.docker.io/COMP4350TheHouse/casino:latest
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/rubyonrails_cd.yml
+++ b/.github/workflows/rubyonrails_cd.yml
@@ -43,11 +43,12 @@ jobs:
         with:
           context: .
           push: true
+          tags: COMP4350TheHouse/casino:latest
           labels: ${{ steps.meta.outputs.labels }}
       
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: index.docker.io/COMP4350TheHouse/casino
+          subject-name: index.docker.io/COMP4350TheHouse/casino:latest
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/rubyonrails_cd.yml
+++ b/.github/workflows/rubyonrails_cd.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: comp4350TheHouse/casino:latest
+          # tags: comp4350TheHouse/casino
           labels: ${{ steps.meta.outputs.labels }}
       
       - name: Generate artifact attestation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       retries: 20
 
   web:
-    image: comp4350thehouse/casino:main
+    image: comp4350thehouse/casino
     build: .
     environment:
       DB_HOST: db


### PR DESCRIPTION
Closes #136. Changes the CD GitHub Action to push to the 'latest' tag.

This has way too many commits. I thought it was not working, but it turns out there was an issue with the DNS server used by GitHub Actions.